### PR TITLE
chore: 📢 Bump version to 0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "rmlm"
-version = "0.0.1-next"
+version = "0.0.2"
 dependencies = [
  "dirs",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmlm"
-version = "0.0.1-next"
+version = "0.0.2"
 edition = "2021"
 authors = ["Florent Benoit <florent.benoit@redhat.com>"]
 description = "A tiny CLI wrapper to run ramalama CLI using podman"


### PR DESCRIPTION
📢 Bump version to 0.0.2

0.0.1 has been released.

 Time to switch to the new 0.0.2 version 🥳
